### PR TITLE
Add filtered mentisdb/tasksquad probes with project scope + dedup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,10 @@ that embed only the probes that passed. Removing a tool and re-running
   breadcrumbs already in this set: the UserPromptSubmit hook dedups across turns
   (a breadcrumb shown on a prior prompt won't re-surface) *and* seeds the set, so
   the PreToolUse hook won't re-fire anything already shown at any prompt. Each
-  layer caps at `MENTIS_MAX` (default 4) breadcrumbs (top by score, after
-  threshold + scope); already-surfaced ones are then suppressed, so a repeated
-  query can show fewer or go quiet.
+  layer caps at `MENTIS_MAX` (default 4) *novel* breadcrumbs per fire — dedup is
+  applied first, then the cap, so a repeated query advances to the next page of
+  results and goes quiet once exhausted (rather than re-showing, starving
+  lower-ranked hits, or falsely reporting "no matches").
 
 ### Hard constraints the generated hooks must keep
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`brainspike` generates two Claude Code hooks that search whatever memory layers
+exist in your environment and inject **breadcrumbs** (titles, summaries, paths,
+IDs + the command to dig deeper) — never full memory contents — into Claude's
+context. The point is to teach the model what to look for, not to dump prior
+context into every turn.
+
+- **UserPromptSubmit hook** (`brainspike.sh`): fires at every human turn, probes
+  active layers with the user's prompt, prints a `=== brainspike ===` block.
+- **PreToolUse hook** (`brainspike-pretool.sh`): fires mid-turn on eligible tool
+  calls (`Grep|Glob|Task|Agent|WebSearch|WebFetch` only), reconstructs a query
+  from the tool input, and injects novel breadcrumbs via
+  `hookSpecificOutput.additionalContext`. This is the precision-first
+  "drift gate" — see `spec/pretooluse-gate-spec.md`.
+
+## Commands
+
+```bash
+./install.sh                                  # probe + register in this project (.claude/settings.local.json)
+./install.sh --global                         # register in ~/.claude/settings.json
+./install.sh --dry-run                        # print plan, write nothing
+./uninstall.sh [--global]                     # remove hooks + unregister
+
+# Tests (no test runner — just run the scripts; both exit non-zero on failure)
+./tests/pretooluse_gate_test.sh               # end-to-end: install, register, fire, dedup, scope
+./tests/pretooluse_rate_sanity.sh             # asserts built matcher == STRONG scope and sim firing rate stays 1.8–2.6/100
+
+# Dev loop — build throwaway hooks and pipe hook-shaped JSON at them
+./install.sh --hook /tmp/bs.sh --pretool-hook /tmp/bs-pre.sh --no-register
+echo '{"prompt":"YAML config validation"}' | /tmp/bs.sh
+echo '{"session_id":"s","tool_name":"Task","tool_input":{"prompt":"YAML config validation"}}' | /tmp/bs-pre.sh
+
+python3 spec/gate_sim.py                       # reproduce the dry-run firing-rate measurement
+```
+
+`BRAINSPIKE_PRETOOL=0` disables the hot-path hook without uninstalling.
+PreToolUse fires are logged as JSON lines to `~/.claude/brainspike-pretool.log`.
+
+## Architecture
+
+The core idea: **the installer is a code generator.** It does not ship the
+hooks — it probes the environment, then *emits* two self-contained bash scripts
+that embed only the probes that passed. Removing a tool and re-running
+`install.sh` cleanly drops it from the generated hook.
+
+- **`probes/*.sh`** — each probe is a sourceable shell file defining
+  `PROBE_NAME`, `PROBE_DESCRIPTION`, and four functions:
+  `probe_detect` (is the layer present?), `probe_test_query` (does it actually
+  respond? — keep fast/cheap), `probe_query "$q"` (print ≤5 breadcrumb lines,
+  format `  - "title" (metadata)`), `probe_breadcrumb` (the dig-deeper command).
+  The installer accepts a probe only if `probe_detect && probe_test_query`
+  succeed in a clean subshell; a syntax error or failure silently skips it.
+- **`install.sh`** — probes `PROBES_DIR`, then builds `$tmp_hook` and
+  `$tmp_pretool_hook` line by line via a large `{ echo ...; } > file` block.
+  Each active probe's file is `cat`'d *verbatim* into the generated hook inside
+  a `( set +u; ... ) &` subshell so probes run concurrently. Registration is an
+  idempotent `jq` merge that preserves existing hooks and refuses to clobber
+  invalid JSON.
+- The two generated hooks share `emit_shared_helpers` (session-state file path +
+  breadcrumb dedup key via `cksum`). Dedup state lives at
+  `$TMPDIR/brainspike/<session_id>.surfaced`. **Both** hooks now suppress
+  breadcrumbs already in this set: the UserPromptSubmit hook dedups across turns
+  (a breadcrumb shown on a prior prompt won't re-surface) *and* seeds the set, so
+  the PreToolUse hook won't re-fire anything already shown at any prompt. Each
+  layer caps at `MENTIS_MAX` (default 4) breadcrumbs (top by score, after
+  threshold + scope); already-surfaced ones are then suppressed, so a repeated
+  query can show fewer or go quiet.
+
+### Hard constraints the generated hooks must keep
+
+- Never exit non-zero (even if every probe explodes — print a fallback, exit 0).
+- Cap each probe at 3s (`timeout`); UserPromptSubmit total ~9s, PreToolUse hot-path
+  ~3s with a tighter ~1.5s per-probe cap (`BRAINSPIKE_PROBE_TIMEOUT`).
+- Emit well under 500 tokens per turn — breadcrumbs, not content.
+- PreToolUse must print a JSON object on stdout (plain stdout is ignored, unlike
+  UserPromptSubmit which injects raw stdout); use `permissionDecision:"allow"` —
+  it annotates, never blocks.
+
+### PreToolUse scope is evidence-gated — do not widen casually
+
+The STRONG scope (`Grep|Glob|Task|Agent|WebSearch|WebFetch`) was chosen because a
+dry-run over 9205 real tool calls showed it fires at 2.2/100 — the drift base
+rate. Adding `Bash` or `file_path` tools (`Read|Edit|Write`) pushes firing to
+3.2–4.7× base (mostly noise) and is **deferred to Phase 2**. Any change to the
+matcher must keep `tests/pretooluse_rate_sanity.sh` green (it re-runs `gate_sim`
+and asserts the built matcher still equals STRONG scope). Read
+`spec/pretooluse-gate-spec.md` before touching scope, dedup, or injection.
+
+### Probe notes
+
+- `probes/mentisdb.sh` queries the mentisdb daemon's `/v1/ranked-search` and is
+  **relevance-filtered, not a recency dump**: it sorts by `score.total`, drops
+  anything below `MENTIS_MIN_SCORE` (default 10), never pads to a fixed count,
+  drops `tasksquad_kind` session-handoff blobs (the dedicated probe handles
+  those), and privileges `[feedback_*]` notes with a lower `MENTIS_FEEDBACK_MIN_SCORE`
+  (default 5). See `tests/mentisdb_probe_test.sh`.
+- **Hard project scope**: drops hits whose *structured* `tags` array names a
+  different project. The signal is a `<prefix><name>` tag convention
+  (`MENTIS_PROJECT_TAG_PREFIX`, default `proj-`); the current project comes from
+  the git repo basename (override `MENTIS_PROJECT`). A hit is foreign iff it
+  carries ≥1 `proj-*` tag and none match the current project — so untagged hits
+  (e.g. the partseeker ASG note, tagged `asg`/`scraper-worker`) and `[feedback_*]`
+  notes are **never** scoped away. Generic by design: it no-ops entirely when no
+  project is known or the response carries no `proj-*` tags, so non-mentisdb
+  platforms are unaffected. `probe_query` caps output to `MENTIS_MAX` (default 4).
+  Note: project identity lives in the structured `tags` array, **not** a content
+  `[bracket]` prefix — claude-mem imports show `[synapse-ai]` etc. in content but
+  the scoping tag is `proj-synapse-ai`.
+- The deployed hooks on this machine are a **hand-curated fork** that the stock
+  `install.sh` cannot yet reproduce: only `mentisdb` + `tasksquad-handoff` run on
+  the per-prompt path (others are on-demand), and the PreToolUse gate is
+  mentisdb-only. `install.sh` currently embeds *every* detected probe into *both*
+  hooks — it has no per-hook / per-prompt membership concept. Do not regenerate
+  the live hooks via `install.sh` without accounting for this, or you re-introduce
+  the per-prompt noise the curation removed.
+
+## Conventions
+
+- Pure bash + `jq`; probes may depend on their own tools (e.g. `claude-mem`
+  needs `python3` + the SQLite DB; `mentisdb` needs `curl` + a daemon on
+  `MENTISDB_HOST`). No build step, no package manager.
+- Custom layers = drop a new `probes/<name>.sh` in and re-run `install.sh`.
+- Probe filtering logic that's correctness-critical lives in a sourceable shell
+  function (e.g. `_mentis_filter`, `_tasksquad_filter`) reading a JSON file, so it
+  stays embeddable verbatim in the generated hook *and* unit-testable from
+  `tests/`.
+- TDD applies to the fire-condition logic (scope filter, query reconstruction,
+  dedup) — `gate_sim.py`'s `in_scope`/`query_entities`/dedup model is the
+  executable reference.

--- a/install.sh
+++ b/install.sh
@@ -137,8 +137,6 @@ BS_HELPERS
     echo 'BRAINSPIKE_TMP="$(mktemp -d 2>/dev/null || mktemp -d -t brainspike)"'
     echo 'trap '"'"'rm -rf "$BRAINSPIKE_TMP"'"'"' EXIT'
     echo
-    echo 'ANY_RESULTS=0'
-    echo
     echo '# --- registry of active layers (for breadcrumbs / fallback) ---'
     echo 'BRAINSPIKE_LAYERS=('
     for n in "${active[@]}"; do
@@ -183,23 +181,30 @@ BS_HELPERS
         cat "$f"
         echo "    output=\"\$(probe_query \"\$PROMPT\" 2>/dev/null || true)\""
         echo "    bc=\"\${BRAINSPIKE_BREADCRUMBS[$n]:-\$(probe_breadcrumb 2>/dev/null)}\""
-        echo "    # Across-turn dedup: only surface breadcrumbs not already shown this session."
+        echo "    # Across-turn dedup: surface only breadcrumbs not shown this session,"
+        echo "    # capped at MENTIS_MAX *novel* lines so a repeated query advances to the"
+        echo "    # next page rather than re-showing or starving rank-N+ hits."
         echo "    novel=\"\$BRAINSPIKE_TMP/$n.novel\""
         echo "    : > \"\$novel\""
+        echo "    matched=0; novelcount=0"
         echo "    while IFS= read -r line; do"
         echo "        [ -n \"\$line\" ] || continue"
-        echo "        if ! brainspike_seen \"$n\" \"\$line\"; then"
-        echo "            printf '%s\\n' \"\$line\" >> \"\$novel\""
-        echo "            brainspike_mark_surfaced \"$n\" \"\$line\""
-        echo "        fi"
+        echo "        matched=1"
+        echo "        brainspike_seen \"$n\" \"\$line\" && continue"
+        echo "        printf '%s\\n' \"\$line\" >> \"\$novel\""
+        echo "        brainspike_mark_surfaced \"$n\" \"\$line\""
+        echo "        novelcount=\$((novelcount+1))"
+        echo "        [ \"\$novelcount\" -ge \"\${MENTIS_MAX:-4}\" ] && break"
         echo "    done <<< \"\$output\""
+        echo "    [ \"\$matched\" = \"1\" ] && echo 1 > \"\$BRAINSPIKE_TMP/$n.matched\""
         echo "    if [ -s \"\$novel\" ]; then"
         echo "        count=\$(grep -c '^' \"\$novel\" 2>/dev/null || echo 0)"
         echo "        printf '%s (%d match%s, run \`%s\` for more):\\n' \"$n\" \"\$count\" \"\$( [ \"\$count\" -eq 1 ] || echo 'es' )\" \"\$bc\" >> \"\$OUT_FILE\""
         echo "        cat \"\$novel\" >> \"\$OUT_FILE\""
         echo "        printf '\\n' >> \"\$OUT_FILE\""
         echo "        echo 1 > \"\$BRAINSPIKE_TMP/$n.hit\""
-        echo "    else"
+        echo "    elif [ \"\$matched\" != \"1\" ]; then"
+        echo "        # Genuinely no matches (distinct from all-seen, which stays silent)."
         echo "        printf '%s: no matches\\n\\n' \"$n\" >> \"\$OUT_FILE\""
         echo "    fi"
         echo ") &"
@@ -214,14 +219,22 @@ BS_HELPERS
     echo 'done'
     echo 'wait 2>/dev/null || true'
     echo
-    echo 'for f in "$BRAINSPIKE_TMP"/*.hit; do'
-    echo '    [ -f "$f" ] && ANY_RESULTS=1'
-    echo 'done'
+    echo 'HAS_NOVEL=0; HAS_MATCH=0'
+    echo 'for f in "$BRAINSPIKE_TMP"/*.hit; do [ -f "$f" ] && HAS_NOVEL=1; done'
+    echo 'for f in "$BRAINSPIKE_TMP"/*.matched; do [ -f "$f" ] && HAS_MATCH=1; done'
     echo
-    echo 'echo "=== brainspike ==="'
-    echo 'if [ "$ANY_RESULTS" = "1" ]; then'
+    echo '# Novel breadcrumbs -> show the block. Matched but all already surfaced this'
+    echo '# session -> stay silent (the dedup did its job; do not re-assert "no matches"'
+    echo '# or re-dump the registry). Nothing matched anywhere -> one-time registry hint.'
+    echo 'if [ "$HAS_NOVEL" = "1" ]; then'
+    echo '    echo "=== brainspike ==="'
     echo '    cat "$OUT_FILE"'
-    echo 'else'
+    echo '    echo'
+    echo '    echo "Consult these before asking the user for context you could find yourself."'
+    echo '    echo "Top results shown per layer (capped, repeats suppressed) — use the commands above for deeper searches."'
+    echo '    echo "=== end brainspike ==="'
+    echo 'elif [ "$HAS_MATCH" != "1" ]; then'
+    echo '    echo "=== brainspike ==="'
     echo '    if [ ${#BRAINSPIKE_LAYERS[@]} -eq 0 ]; then'
     echo '        echo "(no memory layers configured at install time)"'
     echo '    else'
@@ -236,11 +249,8 @@ BS_HELPERS
     echo '            fi'
     echo '        done'
     echo '    fi'
+    echo '    echo "=== end brainspike ==="'
     echo 'fi'
-    echo 'echo'
-    echo 'echo "Consult these before asking the user for context you could find yourself."'
-    echo 'echo "Top results shown per layer (capped, repeats suppressed) — use the commands above for deeper searches."'
-    echo 'echo "=== end brainspike ==="'
     echo 'exit 0'
 } > "$tmp_hook"
 
@@ -309,11 +319,14 @@ BS_HELPERS
         echo "    wait \"\$killer_pid\" 2>/dev/null || true"
         echo "    novel=\"\$BRAINSPIKE_TMP/$n.novel\""
         echo "    : > \"\$novel\""
+        echo "    novelcount=0"
         echo "    while IFS= read -r line; do"
         echo "        [ -n \"\$line\" ] || continue"
         echo "        if ! brainspike_seen \"$n\" \"\$line\"; then"
         echo "            printf '%s\\n' \"\$line\" >> \"\$novel\""
         echo "            brainspike_mark_surfaced \"$n\" \"\$line\""
+        echo "            novelcount=\$((novelcount+1))"
+        echo "            [ \"\$novelcount\" -ge \"\${MENTIS_MAX:-4}\" ] && break"
         echo "        fi"
         echo "    done < \"\$probe_out\""
         echo "    if [ -s \"\$novel\" ]; then"

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,13 @@ BS_HELPERS
     echo
     emit_shared_helpers
     echo
+    echo 'brainspike_seen() {'
+    echo '    local layer="$1" line="$2" state key'
+    echo '    state="$(brainspike_session_file)" || return 1'
+    echo '    key="${layer}:$(brainspike_key "$layer" "$line")"'
+    echo '    grep -Fxq "$key" "$state" 2>/dev/null'
+    echo '}'
+    echo
     echo 'brainspike_mark_surfaced() {'
     echo '    local layer="$1" line="$2" state key'
     echo '    state="$(brainspike_session_file)" || return 0'
@@ -176,13 +183,21 @@ BS_HELPERS
         cat "$f"
         echo "    output=\"\$(probe_query \"\$PROMPT\" 2>/dev/null || true)\""
         echo "    bc=\"\${BRAINSPIKE_BREADCRUMBS[$n]:-\$(probe_breadcrumb 2>/dev/null)}\""
-        echo "    if [ -n \"\$output\" ]; then"
-        echo "        count=\$(printf '%s\\n' \"\$output\" | grep -c '^')"
+        echo "    # Across-turn dedup: only surface breadcrumbs not already shown this session."
+        echo "    novel=\"\$BRAINSPIKE_TMP/$n.novel\""
+        echo "    : > \"\$novel\""
+        echo "    while IFS= read -r line; do"
+        echo "        [ -n \"\$line\" ] || continue"
+        echo "        if ! brainspike_seen \"$n\" \"\$line\"; then"
+        echo "            printf '%s\\n' \"\$line\" >> \"\$novel\""
+        echo "            brainspike_mark_surfaced \"$n\" \"\$line\""
+        echo "        fi"
+        echo "    done <<< \"\$output\""
+        echo "    if [ -s \"\$novel\" ]; then"
+        echo "        count=\$(grep -c '^' \"\$novel\" 2>/dev/null || echo 0)"
         echo "        printf '%s (%d match%s, run \`%s\` for more):\\n' \"$n\" \"\$count\" \"\$( [ \"\$count\" -eq 1 ] || echo 'es' )\" \"\$bc\" >> \"\$OUT_FILE\""
-        echo "        printf '%s\\n\\n' \"\$output\" >> \"\$OUT_FILE\""
-        echo "        while IFS= read -r line; do"
-        echo "            [ -n \"\$line\" ] && brainspike_mark_surfaced \"$n\" \"\$line\""
-        echo "        done <<< \"\$output\""
+        echo "        cat \"\$novel\" >> \"\$OUT_FILE\""
+        echo "        printf '\\n' >> \"\$OUT_FILE\""
         echo "        echo 1 > \"\$BRAINSPIKE_TMP/$n.hit\""
         echo "    else"
         echo "        printf '%s: no matches\\n\\n' \"$n\" >> \"\$OUT_FILE\""
@@ -224,7 +239,7 @@ BS_HELPERS
     echo 'fi'
     echo 'echo'
     echo 'echo "Consult these before asking the user for context you could find yourself."'
-    echo 'echo "Top 5 results shown per layer — use the commands above for deeper searches."'
+    echo 'echo "Top results shown per layer (capped, repeats suppressed) — use the commands above for deeper searches."'
     echo 'echo "=== end brainspike ==="'
     echo 'exit 0'
 } > "$tmp_hook"

--- a/probes/mentisdb.sh
+++ b/probes/mentisdb.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# brainspike probe: mentisdb
+# Ranked-search over the mentisdb daemon's append-only semantic memory.
+# Relevance-filtered (not a recency dump): see _mentis_filter.
+
+PROBE_NAME="mentisdb"
+PROBE_DESCRIPTION="mentisdb semantic memory (ranked search)"
+PROBE_HOST="${MENTISDB_HOST:-http://127.0.0.1:9472}"
+
+probe_detect() {
+    command -v curl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1
+}
+
+probe_test_query() {
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 1 "$PROBE_HOST/v1/chains" 2>/dev/null)" = "200" ]
+}
+
+# Reads a ranked-search JSON payload from $1 (file), prints breadcrumb lines.
+_mentis_filter() {
+    MENTIS_MIN_SCORE="${MENTIS_MIN_SCORE:-10}" \
+    MENTIS_FEEDBACK_MIN_SCORE="${MENTIS_FEEDBACK_MIN_SCORE:-5}" \
+    python3 - "$1" <<'PY'
+import json, os, sys, re
+
+MIN_SCORE = float(os.environ.get("MENTIS_MIN_SCORE", "10"))
+# "How to work with Leigh" feedback notes are the high-value class — give them
+# a lower bar so a moderately-relevant one still surfaces (but not unconditionally).
+FEEDBACK_MIN_SCORE = float(os.environ.get("MENTIS_FEEDBACK_MIN_SCORE", "5"))
+# Hard project scope: drop hits whose structured tags name a *different* project.
+# Generic by design — keys on a `<prefix><name>` tag convention (default "proj-")
+# and no-ops entirely when no current project is known. Untagged hits (no
+# project tag) and feedback notes are never project-scoped away.
+PROJECT = os.environ.get("MENTIS_PROJECT", "").strip().lower()
+PROJECT_TAG_PREFIX = os.environ.get("MENTIS_PROJECT_TAG_PREFIX", "proj-")
+
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+items = data.get("results") or data.get("thoughts") or (data if isinstance(data, list) else [])
+if not isinstance(items, list):
+    sys.exit(0)
+
+def score_of(item):
+    sc = item.get("score")
+    if isinstance(sc, dict):
+        return sc.get("total", 0.0) or 0.0
+    return sc or 0.0
+
+def is_foreign_project(tags):
+    # A hit is foreign iff it carries >=1 project tag and none match PROJECT.
+    # Match is boundary-aware (exact or hyphen-delimited prefix in either
+    # direction) so "partseeker" matches "partseeker-scraper" but project
+    # "art" does NOT spuriously match tag "proj-cart".
+    if not PROJECT:
+        return False
+    proj_tags = [t[len(PROJECT_TAG_PREFIX):].lower()
+                 for t in tags
+                 if isinstance(t, str) and t.startswith(PROJECT_TAG_PREFIX)]
+    proj_tags = [pt for pt in proj_tags if pt]
+    if not proj_tags:
+        return False
+    def matches(pt):
+        return pt == PROJECT or pt.startswith(PROJECT + "-") or PROJECT.startswith(pt + "-")
+    return not any(matches(pt) for pt in proj_tags)
+
+# Relevance-ranked, thresholded — never padded to a fixed count.
+for item in sorted(items, key=score_of, reverse=True):
+    th = item.get("thought") if isinstance(item.get("thought"), dict) else item
+    content = re.sub(r"\s+", " ", (th.get("content") or "").strip())
+    if not content:
+        continue
+    # tasksquad session-handoff blobs are surfaced (scoped + parsed) by the
+    # dedicated tasksquad-handoff probe; here they are pure duplicated noise.
+    if "tasksquad_kind" in content:
+        continue
+    tags = th.get("tags") or []
+    is_feedback = content.startswith("[feedback_") or "feedback" in tags
+    # Cross-project hits are dropped, but never feedback ("how to work with Leigh").
+    if not is_feedback and is_foreign_project(tags):
+        continue
+    floor = FEEDBACK_MIN_SCORE if is_feedback else MIN_SCORE
+    if score_of(item) < floor:
+        continue
+    if len(content) > 80:
+        content = content[:77] + "..."
+    ttype = th.get("thought_type") or ""
+    chain = item.get("chain_key") or th.get("chain_key") or ""
+    date_str = (th.get("timestamp") or th.get("created_at") or "")[:10]
+    meta = ", ".join(x for x in [ttype, chain, date_str] if x)
+    print(f'  - "{content}" ({meta})')
+PY
+}
+
+probe_query() {
+    local query="$1" tmp
+    tmp="$(mktemp)" || return 0
+    # Scope to the current repo (override with MENTIS_PROJECT; empty => no scoping).
+    if [ -z "${MENTIS_PROJECT:-}" ] && command -v git >/dev/null 2>&1; then
+        MENTIS_PROJECT="$(git rev-parse --show-toplevel 2>/dev/null | xargs -r basename 2>/dev/null)"
+    fi
+    export MENTIS_PROJECT
+    timeout 3 curl -s --max-time 3 -X POST "$PROBE_HOST/v1/ranked-search" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -nc --arg q "$query" '{text: $q, limit: 12}')" 2>/dev/null > "$tmp"
+    # Fewer, higher-relevance: cap to the top MENTIS_MAX (default 4) after filtering.
+    _mentis_filter "$tmp" | head -n "${MENTIS_MAX:-4}"
+    rm -f "$tmp"
+}
+
+probe_breadcrumb() {
+    echo 'mb search "<query>"'
+}

--- a/probes/mentisdb.sh
+++ b/probes/mentisdb.sh
@@ -76,7 +76,8 @@ for item in sorted(items, key=score_of, reverse=True):
     # dedicated tasksquad-handoff probe; here they are pure duplicated noise.
     if "tasksquad_kind" in content:
         continue
-    tags = th.get("tags") or []
+    tags = th.get("tags")
+    tags = tags if isinstance(tags, list) else []
     is_feedback = content.startswith("[feedback_") or "feedback" in tags
     # Cross-project hits are dropped, but never feedback ("how to work with Leigh").
     if not is_feedback and is_foreign_project(tags):
@@ -98,15 +99,20 @@ probe_query() {
     local query="$1" tmp
     tmp="$(mktemp)" || return 0
     # Scope to the current repo (override with MENTIS_PROJECT; empty => no scoping).
+    # Portable basename (no xargs -r, space-safe); git -C "$PWD" matches the
+    # sibling tasksquad probe.
     if [ -z "${MENTIS_PROJECT:-}" ] && command -v git >/dev/null 2>&1; then
-        MENTIS_PROJECT="$(git rev-parse --show-toplevel 2>/dev/null | xargs -r basename 2>/dev/null)"
+        MENTIS_PROJECT="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null)"
+        MENTIS_PROJECT="${MENTIS_PROJECT##*/}"
     fi
     export MENTIS_PROJECT
     timeout 3 curl -s --max-time 3 -X POST "$PROBE_HOST/v1/ranked-search" \
         -H "Content-Type: application/json" \
         -d "$(jq -nc --arg q "$query" '{text: $q, limit: 12}')" 2>/dev/null > "$tmp"
-    # Fewer, higher-relevance: cap to the top MENTIS_MAX (default 4) after filtering.
-    _mentis_filter "$tmp" | head -n "${MENTIS_MAX:-4}"
+    # Emit the full relevance-ranked filtered list; the consuming hook applies the
+    # MENTIS_MAX cap *after* across-turn dedup so repeats advance to the next page
+    # rather than starving rank-5+ hits.
+    _mentis_filter "$tmp"
     rm -f "$tmp"
 }
 

--- a/probes/tasksquad-handoff.sh
+++ b/probes/tasksquad-handoff.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# brainspike probe: tasksquad-handoff
+# Surfaces the latest *in-progress* session-handoff for the current repo+branch
+# from mentisdb. Scoped by repo+branch (not the user's query), so it only fires
+# inside tasksquad-managed repos and never leaks other projects' handoffs.
+
+PROBE_NAME="tasksquad-handoff"
+PROBE_DESCRIPTION="paused tasksquad session-handoff for this repo+branch"
+PROBE_HOST="${MENTISDB_HOST:-http://127.0.0.1:9472}"
+
+_tasksquad_repo() {
+    local p="$PWD"
+    while [ "$p" != "/" ]; do
+        [ -d "$p/.tasksquad" ] && return 0
+        { [ -f "$p/core/CLAUDE.md" ] && [ -d "$p/data/wiki" ]; } && return 0
+        p="$(dirname "$p")"
+    done
+    return 1
+}
+
+probe_detect() {
+    command -v curl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
+        && command -v git >/dev/null 2>&1 && _tasksquad_repo
+}
+
+probe_test_query() {
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 1 "$PROBE_HOST/v1/chains" 2>/dev/null)" = "200" ]
+}
+
+# Parse a ranked-search payload ($1) for the latest in-progress handoff matching
+# repo ($2) + branch ($3); print a compact breadcrumb or nothing.
+_tasksquad_filter() {
+    python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+repo, branch = sys.argv[2], sys.argv[3]
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+items = data.get("results") or data.get("thoughts") or (data if isinstance(data, list) else [])
+if not isinstance(items, list):
+    sys.exit(0)
+latest = None
+for item in items:
+    t = item.get("thought", item)
+    try:
+        payload = json.loads(t.get("content") or "")
+    except Exception:
+        continue
+    if not isinstance(payload, dict):
+        continue
+    if payload.get("tasksquad_kind") != "session-handoff":
+        continue
+    if payload.get("repo_name") != repo or payload.get("branch") != branch:
+        continue
+    if latest is None or (payload.get("session_end") or "") > (latest.get("session_end") or ""):
+        latest = payload
+if latest and latest.get("status") == "in-progress":
+    task = latest.get("task_id") or "(no task ID)"
+    ended = (latest.get("session_end") or "")[:10]
+    pend = latest.get("pending") or []
+    nxt = latest.get("next_steps") or []
+    print(f"  - {task}  (paused {ended})")
+    if pend:
+        print(f"    pending: {pend[0]}")
+    if nxt:
+        print(f"    next: {nxt[0]}")
+    print("    run: /dropped-threads  for full detail")
+PY
+}
+
+probe_query() {
+    # The user's query ($1) is intentionally ignored: this probe is scoped by
+    # repo+branch, not by query relevance.
+    local repo branch tmp
+    repo="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {} 2>/dev/null)"
+    branch="$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    { [ -z "$repo" ] || [ -z "$branch" ]; } && return 0
+    tmp="$(mktemp)" || return 0
+    timeout 3 curl -s --max-time 3 -X POST "$PROBE_HOST/v1/ranked-search" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -nc --arg q "session handoff $repo $branch" '{text: $q, limit: 10}')" 2>/dev/null > "$tmp"
+    _tasksquad_filter "$tmp" "$repo" "$branch"
+    rm -f "$tmp"
+}
+
+probe_breadcrumb() {
+    echo '/dropped-threads'
+}

--- a/tests/mentisdb_probe_test.sh
+++ b/tests/mentisdb_probe_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Behaviour tests for probes/mentisdb.sh — the score/relevance filter.
+# Exercises _mentis_filter (the embeddable JSON->breadcrumb stage) against
+# fixed ranked-search payloads, so the three approved fixes are pinned:
+#   (a) score threshold + no padding to 5
+#   (b) drop tasksquad_kind session-handoff content
+#   (c) privilege [feedback_*] LessonLearned with a lower threshold
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT/probes/mentisdb.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() { [[ "$1" == *"$2"* ]] || fail "$3: expected to contain >>$2<<, got: >>$1<<"; }
+assert_missing()  { [[ "$1" != *"$2"* ]] || fail "$3: expected NOT to contain >>$2<<, got: >>$1<<"; }
+assert_empty()    { [ -z "$1" ] || fail "$2: expected empty, got: >>$1<<"; }
+
+rs() { # build a ranked-search result object: rs <total> <type> <content>
+    jq -nc --argjson t "$1" --arg ty "$2" --arg c "$3" \
+        '{chain_key:"personal",score:{total:$t},thought:{thought_type:$ty,content:$c}}'
+}
+rst() { # rs WITH a structured tags array: rst <total> <type> <content> <tags_json>
+    jq -nc --argjson t "$1" --arg ty "$2" --arg c "$3" --argjson tg "$4" \
+        '{chain_key:"personal",score:{total:$t},thought:{thought_type:$ty,content:$c,tags:$tg}}'
+}
+payload() { jq -nc --argjson r "[$(printf '%s,' "$@" | sed 's/,$//')]" '{backend:"x",total:($r|length),results:$r}'; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+filter() { payload "$@" > "$TMP/p.json"; _mentis_filter "$TMP/p.json"; }
+# filter with a current-project scope set: filterp <project> <items...>
+filterp() { local proj="$1"; shift; payload "$@" > "$TMP/p.json"; MENTIS_PROJECT="$proj" _mentis_filter "$TMP/p.json"; }
+
+# (a) high-score relevant item is surfaced
+hi="$(rs 28.5 LessonLearned '[feedback_verbosity_depth] Keep replies terse')"
+out="$(filter "$hi")"
+assert_contains "$out" "Keep replies terse" "high-score surfaced"
+
+# (a) low-score noise is dropped, not padded into the output
+noise="$(rs 8.9 Finding '[synapse-ai] AWS CLI access verified for S3 operations')"
+out="$(filter "$hi" "$noise")"
+assert_contains "$out" "Keep replies terse" "keeps high-score with noise present"
+assert_missing "$out" "AWS CLI access"        "drops sub-threshold noise"
+
+# (b) tasksquad session-handoff JSON is excluded (handled by its own probe)
+tsq="$(rs 30 FactLearned '{"tasksquad_kind": "session-handoff", "status": "in-progress", "task_id": "T1"}')"
+out="$(filter "$hi" "$tsq")"
+assert_contains "$out" "Keep replies terse"  "keeps real hit alongside tasksquad"
+assert_missing "$out" "tasksquad_kind"        "drops tasksquad session-handoff JSON"
+
+# (c) [feedback_*] LessonLearned is privileged: surfaces below the main floor;
+#     a generic item at the same score does not.
+fb_mid="$(rs 6 LessonLearned '[feedback_check_memory_first] Check memory before asking')"
+gen_mid="$(rs 6 Finding '[synapse-ai] some unrelated finding')"
+out="$(filter "$fb_mid" "$gen_mid")"
+assert_contains "$out" "Check memory before asking" "privileges feedback below main floor"
+assert_missing  "$out" "unrelated finding"           "generic item at same score dropped"
+
+# but a feedback note below even the feedback floor is still dropped (not unconditional)
+fb_low="$(rs 1 LessonLearned '[feedback_check_memory_first] Check memory before asking')"
+out="$(filter "$fb_low")"
+assert_empty "$out" "feedback below feedback floor is dropped"
+
+# (d) hard project filter — scope to the current repo via structured proj-* tags.
+#     Identity lives in the `tags` array (proj-<name>); cross-project hits drop,
+#     untagged/feedback hits survive, and the filter no-ops when unscoped.
+foreign="$(rst 40 Insight 'piebald deploy notes' '["proj-piebald"]')"
+own="$(rst 40 Insight 'brainspike hook design' '["proj-brainspike"]')"
+asg="$(rst 16 Insight 'partseeker-scraper-worker ASG owned by CloudWatch alarms' '["asg","scraper-worker","aws"]')"
+
+out="$(filterp brainspike "$foreign")"
+assert_empty "$out" "foreign proj-* tag dropped under project scope"
+
+out="$(filterp brainspike "$own")"
+assert_contains "$out" "brainspike hook design" "matching proj-* tag kept under project scope"
+
+out="$(filterp brainspike "$asg")"
+assert_contains "$out" "ASG owned by CloudWatch" "non-proj-tagged hit kept under project scope"
+
+# boundary-aware match: repo token is a hyphen-delimited prefix of a proj tag
+own_sub="$(rst 40 Insight 'partseeker scraper pricing' '["proj-partseeker-scraper"]')"
+out="$(filterp partseeker "$own_sub")"
+assert_contains "$out" "partseeker scraper pricing" "proj tag with the repo token as a hyphen-prefix kept"
+
+# boundary-aware match: a bare substring (not hyphen-delimited) is NOT a match
+not_boundary="$(rst 40 Insight 'shopping cart service' '["proj-cart"]')"
+out="$(filterp art "$not_boundary")"
+assert_empty "$out" "substring-but-not-boundary proj tag treated as foreign"
+
+# feedback is exempt even if it somehow carries a foreign proj-* tag
+fb_foreign="$(rst 40 LessonLearned '[feedback_verbosity_depth] terse please' '["proj-piebald","feedback"]')"
+out="$(filterp brainspike "$fb_foreign")"
+assert_contains "$out" "terse please" "feedback exempt from project filter"
+
+# no current project => filter inactive (cross-project hit retained)
+payload "$foreign" > "$TMP/p.json"
+out="$(MENTIS_PROJECT='' _mentis_filter "$TMP/p.json")"
+assert_contains "$out" "piebald deploy notes" "no project scope => foreign hit retained"
+
+echo "mentisdb probe tests passed"

--- a/tests/pretooluse_gate_test.sh
+++ b/tests/pretooluse_gate_test.sh
@@ -40,6 +40,7 @@ probe_query() {
     case "$query" in
         *alpha*) printf '  - "Alpha decision" (fixture/alpha.md)\n' ;;
         *bravo*) printf '  - "Bravo note" (fixture/bravo.md)\n' ;;
+        *multi*) printf '  - "Multi one" (fixture/m1.md)\n  - "Multi two" (fixture/m2.md)\n  - "Multi three" (fixture/m3.md)\n' ;;
     esac
 }
 
@@ -130,5 +131,32 @@ seeded="$("$PRETOOL_HOOK" <<'JSON'
 JSON
 )"
 assert_empty "$seeded" "PreToolUse dedups against UserPromptSubmit surfaced set"
+
+# --- per-prompt across-turn dedup / cap / all-seen behaviour (regression guards) ---
+
+# All-seen: a layer that matched but whose hits were all surfaced earlier must go
+# SILENT — not falsely print "no matches" and not dump the layer registry.
+allseen1="$(printf '%s\n' '{"session_id":"session-e","prompt":"alpha"}' | "$HOOK")"
+assert_contains "$allseen1" "Alpha decision" "all-seen turn 1 surfaces the breadcrumb"
+allseen2="$(printf '%s\n' '{"session_id":"session-e","prompt":"alpha"}' | "$HOOK")"
+assert_empty "$allseen2" "all-seen turn 2 is silent (no false no-matches, no registry dump)"
+
+# Genuinely-empty (no layer matched at all) still shows the registry fallback.
+emptyq="$(printf '%s\n' '{"session_id":"session-f","prompt":"zzz-unmatchable-qwerty"}' | "$HOOK")"
+assert_contains "$emptyq" "No matches in any layer" "genuinely-empty query shows registry fallback"
+
+# Cap + paging: with MENTIS_MAX=2 a 3-result query shows 2 (capped) on turn 1, then
+# advances to the remaining 1 on turn 2 (dedup), then goes silent once exhausted.
+export MENTIS_MAX=2
+page1="$(printf '%s\n' '{"session_id":"session-g","prompt":"multi"}' | "$HOOK")"
+assert_contains "$page1" "Multi one"  "cap/paging turn 1 includes first"
+assert_contains "$page1" "Multi two"  "cap/paging turn 1 includes second"
+[[ "$page1" != *"Multi three"* ]] || fail "cap: turn 1 must not exceed MENTIS_MAX=2"
+page2="$(printf '%s\n' '{"session_id":"session-g","prompt":"multi"}' | "$HOOK")"
+assert_contains "$page2" "Multi three" "paging turn 2 advances to the next page"
+[[ "$page2" != *"Multi one"* ]] || fail "dedup: turn 2 must not repeat turn 1"
+page3="$(printf '%s\n' '{"session_id":"session-g","prompt":"multi"}' | "$HOOK")"
+assert_empty "$page3" "paging exhausted => silent"
+unset MENTIS_MAX
 
 echo "pretooluse gate tests passed"

--- a/tests/tasksquad_probe_test.sh
+++ b/tests/tasksquad_probe_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Behaviour tests for probes/tasksquad-handoff.sh — the handoff parser.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT/probes/tasksquad-handoff.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() { [[ "$1" == *"$2"* ]] || fail "$3: expected >>$2<<, got: >>$1<<"; }
+assert_empty()    { [ -z "$1" ] || fail "$2: expected empty, got: >>$1<<"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+hand() { jq -nc --argjson p "$1" '{results:[{thought:{content:($p|tostring)}}]}'; }
+filter() { hand "$1" > "$TMP/p.json"; _tasksquad_filter "$TMP/p.json" "$2" "$3"; }
+
+inprog='{"tasksquad_kind":"session-handoff","repo_name":"brainspike","branch":"main","status":"in-progress","session_end":"2026-06-15T01:00:00","task_id":"T-42","pending":["wire probe"],"next_steps":["regenerate hook"]}'
+
+# in-progress handoff for matching repo+branch is surfaced
+out="$(filter "$inprog" brainspike main)"
+assert_contains "$out" "T-42"            "surfaces in-progress task id"
+assert_contains "$out" "pending: wire probe" "surfaces first pending item"
+assert_contains "$out" "/dropped-threads"     "surfaces breadcrumb"
+
+# wrong branch is ignored
+out="$(filter "$inprog" brainspike other)"
+assert_empty "$out" "ignores handoff for a different branch"
+
+# completed handoff is not surfaced
+done_h="${inprog/in-progress/completed}"
+out="$(filter "$done_h" brainspike main)"
+assert_empty "$out" "ignores completed handoff"
+
+echo "tasksquad probe tests passed"


### PR DESCRIPTION
## What
Brings the two bespoke memory probes (`mentisdb`, `tasksquad-handoff`) into the repo and tightens the per-prompt memory injection: relevance threshold (no padding), **hard project scope** via structured `proj-*` tags, **across-turn dedup**, and a per-fire **count cap** (`MENTIS_MAX`, default 4).

## Why
Using-agents reported the per-prompt injection was ~1:4 signal:noise — cross-project hits (piebald/synapse-ai/image-downloader/llama.cpp) recurred every turn, drowning the useful feedback/scraper memories. Three asks: scope to current repo, dedup within a session, fewer/higher-relevance. All three implemented; kept generic so it no-ops on any non-mentisdb platform (brainspike is OSS).

Design notes: project identity = the structured `tags` array (`proj-<name>`), **not** a content `[bracket]` prefix. Untagged hits (e.g. the partseeker ASG note) and `[feedback_*]` notes are never scoped away. Match is boundary-aware so `art` ≠ `proj-cart`.

## How verified
Driven end-to-end through the **real `./install.sh`-generated** hooks (not just unit harnesses):

- **Suite** (`bash tests/*.sh`): `mentisdb_probe_test`, `tasksquad_probe_test`, `pretooluse_gate_test` all PASS; `bash -n` clean on all 9 shell files.
  - `pretooluse_rate_sanity` fails **pre-existing/environmental only** — `research/driftmine/dm_parse.py` crashes reading a deleted transcript; identical failure with this branch's changes stashed; the STRONG matcher it guards is untouched.
- **Scope** (real daemon): unscoped 12 results → scoped-to-`partseeker` 7 — every `proj-synapse-ai`/`proj-image-downloader` hit dropped, all `[feedback_*]` + partseeker/scraper hits kept. Foreign-leakage grep over generated-hook output = **0**.
- **Cap**: generated hook turn 1 mentisdb = exactly **4** breadcrumbs.
- **Dedup**: turn 2 of the same session suppressed all 4; T1∩T2 overlap = **0**.
- **Boundary match**: new test pins project `art` treats tag `proj-cart` as foreign (dropped).
- **Edge cases**: empty prompt / missing `prompt` key / normal fire → **exit 0** (hooks never exit non-zero); pretool ignores non-eligible `Read`; eligible `Grep`/`Task` emits valid `permissionDecision:"allow"` JSON.
- **Reliability**: curl bounded (`--max-time 3` + `timeout 3`), temp dirs trap-cleaned, failures swallowed (python try/except), no secrets.

## Risk / rollback
Low. Purely additive (two new probe files + tests + docs) plus a localized `install.sh` change (the per-prompt loop now filters to novel lines before printing, using the same dedup helpers the PreToolUse hook already used). Does not touch the PreToolUse STRONG scope matcher. The deployed `~/.claude/hooks/*.sh` are a hand-curated fork and are **not** regenerated by this change. Rollback = revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic memory search probe for ranked results
  * Added task handoff tracking probe to surface paused workflow tasks

* **Improvements**
  * Breadcrumb results now suppress duplicate entries within a session

* **Documentation**
  * Added comprehensive repository guidance for hook configuration

* **Tests**
  * Added test suites for new search and handoff probes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->